### PR TITLE
Updated to force lowercase checks in unswear.py

### DIFF
--- a/unswear.py
+++ b/unswear.py
@@ -43,7 +43,7 @@ class Recorder:
             self.handle_backspace()
 
         if type(key) is KeyCode and key.char is not None:
-            self.buffer += key.char
+            self.buffer += key.char.lower()
 
     def handle_backspace(self):
         """


### PR DESCRIPTION
As you type, it will now force lower case during checks

fixed issue #9 where having 1 uppercase in a word that's on the filter list gets bypassed.

example:

typing ``Suck`` won't trigger it to change to hold, but with the new change doesn't matter how you capitalize it ``Suck / sUck / etc,`` it will all get changed to hold as it's supposed to according to replacements.csv